### PR TITLE
Fix layout for development documentation pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,9 +22,11 @@
 
       <div class="trigger">
         {% for page in site.pages %}
-          {% if page.title %}
-          <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-          {% endif %}
+          {% unless page.exclude %}
+            {% if page.title %}
+            <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+            {% endif %}
+          {% endunless %}
         {% endfor %}
       </div>
     </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Developer Documentation
+permalink: /docs/
+exclude: true
+---
+<div class="home">
+
+  <ul class="post-list">
+    {% for post in paginator.posts %}
+      {% if post.displayed %}
+      <li>
+        <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">
+          {% if post.featured_image %}
+          <img class="featured-image" src="{{ site.image_url }}/{{ post.featured_image.url }}" />
+          {% endif %}
+          <h2>{{ post.title }}</h2>
+          <h3>{{ post.teaser }}</h3>
+        </a>
+      </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+
+  {% if paginator.previous_page or paginator.next_page %}
+  <nav class="pagination">
+    {% if paginator.previous_page %}
+      <a href="{{ paginator.previous_page_path }}" class="previous">← Previous page</a>
+    {% endif %}
+    <span class="page-number">Page {{ paginator.page }} of {{ paginator.total_pages }}</span>
+    {% if paginator.next_page %}
+      <a href="{{ paginator.next_page_path }}" class="next">More posts →</a>
+    {% endif %}
+  </nav>
+  {% endif %}
+</div>
+
+<div class="post-list">
+  Start off by <a href="https://github.com/daily-bruin/the-stack/blob/master/README.md">installing Jekyll</a>.
+    Then, acquainted with <a href="/docs/website-code/">how to develop for the Stack</a>.
+    Finally, keep in mind our <a href="/docs/workflow/">workflow</a>.
+</div>

--- a/docs/usage-and-style.md
+++ b/docs/usage-and-style.md
@@ -1,5 +1,6 @@
 ---
 layout: page
+permalink: /docs/usage-and-style/
 ---
 
 # Usage documentation and style guidelines

--- a/docs/website-code.md
+++ b/docs/website-code.md
@@ -1,5 +1,6 @@
 ---
 layout: page
+permalink: /docs/website-code/
 ---
 
 # Website code documentation

--- a/docs/website-code.md
+++ b/docs/website-code.md
@@ -1,4 +1,5 @@
 ---
+layout: page
 ---
 
 # Website code documentation

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,4 +1,5 @@
 ---
+layout: page
 ---
 
 # Workflow

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,5 +1,6 @@
 ---
 layout: page
+permalink: /docs/workflow/
 ---
 
 # Workflow


### PR DESCRIPTION
Behold before: 

<img width="1440" alt="screen shot 2016-02-09 at 6 14 52 pm" src="https://cloud.githubusercontent.com/assets/4713937/12937016/0d37f61e-cf59-11e5-9d0f-39dc2909e04a.png">

And after: 

<img width="1440" alt="screen shot 2016-02-09 at 6 14 59 pm" src="https://cloud.githubusercontent.com/assets/4713937/12937017/11fef10c-cf59-11e5-89af-9757f846b1dc.png">
